### PR TITLE
Support darwin arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 *.tfstate
 *.tfstate.backup
 */terraform.tfvars
-
+*/.terraform.lock.hcl
 .DS_Store

--- a/terraform_setup/ecs.tf
+++ b/terraform_setup/ecs.tf
@@ -108,9 +108,9 @@ resource "aws_ecs_service" "main" {
   }
 
   depends_on = [
-    "aws_iam_role.ecs",
-    "aws_ecr_repository.app_repository",
-    "aws_lb_listener_rule.all"
+    aws_iam_role.ecs,
+    aws_ecr_repository.app_repository,
+    aws_lb_listener_rule.al
   ]
 }
 

--- a/terraform_setup/provider.tf
+++ b/terraform_setup/provider.tf
@@ -2,5 +2,14 @@ provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "${var.aws_region}"
-  version = "~> 1.35"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+  required_version = ">= 1.2.0"
 }


### PR DESCRIPTION
when running `terraform init` i got prompted with 

```
Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 1.35"...
╷
│ Warning: Quoted references are deprecated
│ 
│   on ecs.tf line 111, in resource "aws_ecs_service" "main":
│  111:     "aws_iam_role.ecs",
│ 
│ In this context, references are expected literally rather than in quotes. Terraform 0.11
│ and earlier required quotes, but quoted references are now deprecated and will be
│ removed in a future version of Terraform. Remove the quotes surrounding this reference
│ to silence this warning.
│ 
│ (and 5 more similar warnings elsewhere)
╵

╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│ 
│   on provider.tf line 5, in provider "aws":
│    5:   version = "~> 1.35"
│ 
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider
│ configuration block, but that is now deprecated and will be removed in a future version
│ of Terraform. To silence this warning, move the provider version constraint into the
│ required_providers block.
│ 
│ (and one more similar warning elsewhere)
╵

╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/aws v1.60.0 does not have a package available
│ for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are
│ available for all platforms. Other versions of this provider may have different
│ platforms supported.
╵
```

this PR comes to resolve these issues 